### PR TITLE
Change livenessProbe endpoint away from metrics

### DIFF
--- a/charts/mozilla-common-voice/templates/deployment.yaml
+++ b/charts/mozilla-common-voice/templates/deployment.yaml
@@ -33,7 +33,7 @@ spec:
         livenessProbe:
           httpGet:
             port: 9000
-            path: /api/v1/metrics
+            path: /api/v1/golem
           periodSeconds: 10
           initialDelaySeconds: 60
           successThreshold: 1


### PR DESCRIPTION
Change livenessProbe endpoint to `/golem` which returns a 302 (anything <400 indicates success according to the docs https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-a-liveness-http-request ). Once this is deployed and confirmed successful, the Prometheus code can be removed from CV!